### PR TITLE
Browser prepend external links to current domain

### DIFF
--- a/client/src/components/profile/ProfileTop.js
+++ b/client/src/components/profile/ProfileTop.js
@@ -21,34 +21,34 @@ const ProfileTop = ({
       <p>{location && <span>{location}</span>}</p>
       <div className="icons my-1">
         {website && (
-          <a href={website} target="_blank" rel="noopener noreferrer">
+          <a href={`//${website}`} target="_blank" rel="noopener noreferrer">
             <i className="fas fa-globe fa-2x"></i>
           </a>
         )}
 
         {social && social.twitter && (
-          <a href={social.twitter} target="_blank" rel="noopener noreferrer">
+          <a href={`//${social.twitter}`} target="_blank" rel="noopener noreferrer">
             <i className="fab fa-twitter fa-2x"></i>
           </a>
         )}
 
         {social && social.facebook && (
-          <a href={social.facebook} target="_blank" rel="noopener noreferrer">
+          <a href={`//${social.facebook}`} target="_blank" rel="noopener noreferrer">
             <i className="fab fa-facebook fa-2x"></i>
           </a>
         )}
         {social && social.linkedin && (
-          <a href={social.linkedin} target="_blank" rel="noopener noreferrer">
+          <a href={`//${social.linkedin}`} target="_blank" rel="noopener noreferrer">
             <i className="fab fa-linkedin fa-2x"></i>
           </a>
         )}
         {social && social.youtube && (
-          <a href={social.youtube} target="_blank" rel="noopener noreferrer">
+          <a href={`//${social.youtube}`} target="_blank" rel="noopener noreferrer">
             <i className="fab fa-youtube fa-2x"></i>
           </a>
         )}
         {social && social.instagram && (
-          <a href={social.instagram} target="_blank" rel="noopener noreferrer">
+          <a href={`//${social.instagram}`} target="_blank" rel="noopener noreferrer">
             <i className="fab fa-instagram fa-2x"></i>
           </a>
         )}


### PR DESCRIPTION
When social media links clicked -even though it is anchor tag- it opens like `localhost:3000/www.twitter.com/example`. So I added '//' into every `href` before external links in order to prevent browser from prepending current domain to external links.