### PR TITLE
Not logging out properly

### DIFF
--- a/client/src/redux/actions/authAction.js
+++ b/client/src/redux/actions/authAction.js
@@ -96,6 +96,7 @@ export const login = (email, password) => async dispatch => {
 
 // Logout / Clear Profile
 export const logout = () => dispatch => {
+  setAuthToken();
   dispatch({ type: CLEAR_PROFILE });
   dispatch({ type: LOGOUT });
 };

--- a/client/src/redux/reducers/authReducer.js
+++ b/client/src/redux/reducers/authReducer.js
@@ -47,7 +47,7 @@ export default function(state = initialState, action) {
         token: null,
         isAuthenticated: false,
         loading: false,
-        // should have set user to null !!!
+        user: null,
       };
     default:
       return state;


### PR DESCRIPTION
When a user logout, user info remains in state. 
But the bigger problem is when logout, axios default headers still have the authorization token. So, even if logged out, auth middleware still allows requests to reach private endpoints because of remaining token if the page is not refreshed. (`setAuthToken` sets and deletes default headers)

Added `setAuthToken()` into `logout` action to delete the token from axios headers, added `user: null` into reducer.